### PR TITLE
Resetted Priority of Plugin

### DIFF
--- a/opitz-camunda-cockpit-plugin-bpmn-stats/src/main/resources/plugin-webapp/bpmn-stats/app/views/processDefinition/statsTable.js
+++ b/opitz-camunda-cockpit-plugin-bpmn-stats/src/main/resources/plugin-webapp/bpmn-stats/app/views/processDefinition/statsTable.js
@@ -50,7 +50,7 @@ ngDefine('cockpit.plugin.bpmn-stats.views', function(module) {
       label: 'Statistics',
       url: 'plugin://bpmn-stats/static/app/views/processDefinition/stats-table.html',
       controller: 'BpmnStatsController',
-      priority: 19
+      priority: 0
     });
   };
 


### PR DESCRIPTION
Better not to have this plugin as the most left tab - makes it easier to include it without having it too prominent.
